### PR TITLE
Add S3 cleanup workflow

### DIFF
--- a/.github/workflows/cleanup-s3.yml
+++ b/.github/workflows/cleanup-s3.yml
@@ -1,0 +1,26 @@
+name: Cleanup old S3 files
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # Daily at 6:00 UTC
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Cleanup old report files (>15 days)
+        run: ./scripts/cleanup-old-s3-files.sh ${{ secrets.S3_BUCKET }}/ 15
+
+      - name: Cleanup old CTRF files (>2 days)
+        run: ./scripts/cleanup-old-s3-files.sh ${{ secrets.S3_BUCKET }}/reports/ctrf/ 2

--- a/.github/workflows/cleanup-s3.yml
+++ b/.github/workflows/cleanup-s3.yml
@@ -20,7 +20,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Cleanup old report files (>15 days)
-        run: ./scripts/cleanup-old-s3-files.sh ${{ secrets.S3_BUCKET }}/ 15
+        run: ./scripts/cleanup-old-s3-files.sh ${{ secrets.AWS_S3_BUCKET_BASE_URL }}/ 15
 
       - name: Cleanup old CTRF files (>2 days)
-        run: ./scripts/cleanup-old-s3-files.sh ${{ secrets.S3_BUCKET }}/reports/ctrf/ 2
+        run: ./scripts/cleanup-old-s3-files.sh ${{ secrets.AWS_S3_BUCKET_BASE_URL }}/reports/ctrf/ 2


### PR DESCRIPTION
#### Proposed Changes

* Add scheduled GitHub workflow to automatically cleanup old files from S3 buckets
* Configured to run daily, removing general reports older than 15 days and CTRF reports older than 2 days
* Uses existing `cleanup-old-s3-files.sh` script with AWS credentials from repository secrets

#### Testing Instructions

* Verify workflow runs on schedule or trigger manually via Actions tab
* Confirm S3 bucket configuration uses `S3_BUCKET` secret
* Review workflow logs to validate cleanup execution