### PR TITLE
Fix cleanup workflow AWS credentials access

### DIFF
--- a/.github/workflows/cleanup-s3.yml
+++ b/.github/workflows/cleanup-s3.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    environment: github-pages
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
#### Proposed Changes

- Add `environment: github-pages` to the cleanup job so it can access AWS secrets scoped to that environment
- Fixes the 'aws-region input required and not supplied' error in the cleanup-s3 workflow

#### Testing Instructions

The cleanup workflow should now run successfully when triggered, with proper AWS credentials configured.