### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/cleanup-s3.yml
+++ b/.github/workflows/cleanup-s3.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/generate-report.yml
+++ b/.github/workflows/generate-report.yml
@@ -42,7 +42,7 @@ jobs:
         run: npm install -g allure-commandline
           
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

Tracking: DEVPROD-1072

Repo-level summary:
- Pinned distinct third-party action refs in this PR: 2
- Repo-level unpinned usage count from the trunk recheck: 2
- Dependabot GitHub Actions coverage: created (.github/dependabot.yml)


Verification commands:

```bash
# aws-actions/configure-aws-credentials # v1.7.0 -> 67fbcbb121271f7775d2e7715933280b06314838
gh api repos/aws-actions/configure-aws-credentials/commits/v1.7.0 --jq '.sha'
# expected: 67fbcbb121271f7775d2e7715933280b06314838

# aws-actions/configure-aws-credentials # v4.3.1 -> 7474bc4690e29a8392af63c5b98e7449536d5c3a
gh api repos/aws-actions/configure-aws-credentials/commits/v4.3.1 --jq '.sha'
# expected: 7474bc4690e29a8392af63c5b98e7449536d5c3a
```
